### PR TITLE
added channel limitation for normal users

### DIFF
--- a/bots/tipbot.js
+++ b/bots/tipbot.js
@@ -30,17 +30,21 @@ function respond(bot, data) {
   var tipper = data.user,
       channel = data.channel,
       words = data.text.trim().split(' ').filter( function(n){return n !== "";} );
-
+  
+  if (words[0] !== command) {
+    // if the received message isn't starting with the trigger -> ignore
+    return;
+  }
+  
   if (!lbry) {
     bot.postMessage(channel, 'Failed to connect to lbrycrd', {icon_emoji: ':exclamation:'});
     return;
   }
 
-  if (words[0] !== command) {
-    // wtf?
-    return;
+  if (!tipper.is_admin || !tipper.is_owner || channel.name !== "bot-sandbox" ){
+	bot.postMessage(channel, 'Please help keep the channel clean: use #bot-sandbox', globalSlackParams);  
   }
-
+  
   var subcommand = words.length >= 2 ? words[1] : 'help';
 
   if (subcommand === 'help') {

--- a/bots/tipbot.js
+++ b/bots/tipbot.js
@@ -42,7 +42,8 @@ function respond(bot, data) {
   }
 
   if ((!tipper.is_admin || !tipper.is_owner) && channel.name !== "bot-sandbox" ){
-	bot.postMessage(channel, 'Please help keep the channel clean: use #bot-sandbox', globalSlackParams);  
+	bot.postMessage(channel, 'Please help keep the channel clean: use #bot-sandbox', globalSlackParams); 
+	return;	
   }
   
   var subcommand = words.length >= 2 ? words[1] : 'help';

--- a/bots/tipbot.js
+++ b/bots/tipbot.js
@@ -41,12 +41,16 @@ function respond(bot, data) {
     return;
   }
 
-  if ((!tipper.is_admin || !tipper.is_owner) && channel.name !== "bot-sandbox" ){
-	bot.postMessage(channel, 'Please help keep the channel clean: use #bot-sandbox', globalSlackParams); 
-	return;	
-  }
-  
   var subcommand = words.length >= 2 ? words[1] : 'help';
+  var isAllowedTip = false;
+  if ((!tipper.is_admin || !tipper.is_owner) && channel.name !== 'bot-sandbox' ){
+	//to check if the command is a tip (hence allowed to pass through) we need to check against all the other commands)
+	if (subcommand === 'help' || subcommand === 'balance' || subcommand === 'deposit' || subcommand === 'withdraw'){
+		bot.postMessage(channel, 'Please help keep the channel clean: use #bot-sandbox', globalSlackParams); 
+		return;	
+	}
+	isAllowedTip = true;
+  }
 
   if (subcommand === 'help') {
     doHelp(bot, channel);
@@ -61,7 +65,7 @@ function respond(bot, data) {
     doWithdraw(bot, channel, tipper, words);
   }
   else {
-    doTip(bot, channel, tipper, words);
+    doTip(bot, channel, tipper, words, isAllowedTip);
   }
 }
 
@@ -116,9 +120,11 @@ function doWithdraw(bot, channel, tipper, words) {
 }
 
 
-function doTip(bot, channel, tipper, words) {
+function doTip(bot, channel, tipper, words, isAllowedTip) {
   if (words.length < 3) {
-    doHelp(bot, channel);
+	//necessary to avoid the help menu opening up on all channels
+	if (!isAllowedTip)
+		doHelp(bot, channel);
     return;
   }
 

--- a/bots/tipbot.js
+++ b/bots/tipbot.js
@@ -41,7 +41,7 @@ function respond(bot, data) {
     return;
   }
 
-  if (!tipper.is_admin || !tipper.is_owner || channel.name !== "bot-sandbox" ){
+  if ((!tipper.is_admin || !tipper.is_owner) && channel.name !== "bot-sandbox" ){
 	bot.postMessage(channel, 'Please help keep the channel clean: use #bot-sandbox', globalSlackParams);  
   }
   


### PR DESCRIPTION
I added channel limitation for normal users so that they can only use the bot in \#bot-sandbox, also I moved the trigger check further back in the function, it's not really necessary to check the connection if the user isn't trying to use the bot.

I have no means of checking whether it works or not. But perhaps this helps clearing up the spam generated by the bot usage on any slack channel.