### PR TITLE
show entire claim ID in claims

### DIFF
--- a/bot/modules/claimbot.js
+++ b/bot/modules/claimbot.js
@@ -227,7 +227,10 @@ function announceClaim(claim, claimBlockHeight, currentHeight) {
               icon_url:
                 "http://barkpost-assets.s3.amazonaws.com/wp-content/uploads/2013/11/3dDoge.gif"
             },
-            title: (channelName ? channelName + "/" : "") + claim["name"],
+            title:
+              "lbry://" +
+              (channelName ? channelName + "/" : "") +
+              claim["name"],
             color: 1399626,
             description: escapeSlackHtml(text.join("\n")),
             footer: {


### PR DESCRIPTION
"jiggytom: @Nikooo777 anyway to fix the content bot cutting off the claim ID? I also think we should show the entire lbry:// url in the title.. What do you think? Can we make the claim takeover part bold too?"