### PR TITLE
Simplify rolesetter.js Control Logic

### DIFF
--- a/bot/modules/rolesetter.js
+++ b/bot/modules/rolesetter.js
@@ -13,47 +13,46 @@ exports.addrole = {
   usage: '<role>',
   description: 'Adds you to specified role',
   process: function(bot, msg, suffix) {
-    //rolelist.allowedroles = rolelist.allowedroles.map(v => v.toLowerCase());
-    // Here the bot,msg and suffix is avaible, this function can be async if needed.
-    let newrole = msg.guild.roles.find('name', suffix);
+    // Here the bot, msg and suffix is avaible, this function can be async if needed.
+    // Make sure to eliminate case sensitivity, do this here to only perform the sweep once.
+    let newrole = msg.guild.roles.find(role => role.name.toLowerCase() === suffix.toLowerCase());
+    // Baserole is assumed to already be case accurate as it's handled in the config itself.
     let baserole = msg.guild.roles.find('name', rolelist.baserole);
-    // Checks if the user put a role in the message.
-    if (inPrivate(msg)) {
-      msg.channel.send('You can not set roles in DMs! Please go to the Discord server to do this.');
+    
+    // Provide shortened syntax for the sake of code cleanliness
+    let send = (msgTxt) => { msg.channel.send(msgTxt); return; };
+    let rolecmd = botconfig.prefix + "roles";
+    
+    // Checks if the user has messaged the bot via Direct Message
+    if (inPrivate(msg))
+      return send('You can not set roles in DMs! Please go to the Discord server to do this.');
+    // Checks if the user included a role in their message
+    if (!suffix)
+      return send("Please specify a role. Type " + rolecmd + " to see which you may add yourself!");
+    // Checks if there is a matching role found on the server
+    if(!newrole)
+      return send("The role specified `" + suffix + "` does not exist on this server!");
+    // Checks that the allowed roles and base role against the matched role's name, since this eliminates case sensitivity issues
+    if(!rolelist.allowedroles.includes(newrole.name) && !rolelist.baserole.includes(newrole.name))
+      return send("That role isn't one you can add yourself to! Type " + rolecmd + " command to find out which ones are allowed.");
+    // Use the matched name to check against the member's existing roles
+    if(msg.member.roles.find('name', newrole.name))
+      return send("It seems you already have the " + newrole.name + "role");
+    
+    // Assuming all these factors succeed, add the role
+    msg.member.addRole(newrole).then(send(msg.member + " has been added to the " + newrole.name + " role!"));
+    
+    // Check if a baserole is actually set
+    if(!rolelist.baserole)
       return;
-    } else {
-      if (suffix) {
-        //suffix = suffix.toLowerCase();
-        // Checks if the role mentioned in the message is in the allowed roles listed in the wunderbot config.
-        if (rolelist.allowedroles.includes(suffix) || rolelist.baserole.includes(suffix)) {
-          // Checks if the role even exists in the discord server
-          if (newrole !== null) {
-            // Checks if the member has the role that they are trying to add
-            if (!msg.member.roles.find('name', suffix)) {
-              msg.member.addRole(newrole).then(msg.channel.send(msg.member + ' has been added to the ' + suffix + ' role!'));
-              if (rolelist.baserole !== ' ') {
-                if (baserole !== null) {
-                  // Checks if Member has the baserole, and also checks if they just added the baserole
-                  if (!msg.member.roles.find('name', rolelist.baserole) && suffix !== rolelist.baserole) {
-                    msg.member.addRole(baserole).then(msg.channel.send(msg.member + ' has been added to the ' + rolelist.baserole + ' role!'));
-                  }
-                } else {
-                  msg.channel.send('The ' + rolelist.baserole + " Role doesn't exist. Please add that role first!");
-                }
-              }
-            } else {
-              msg.channel.send('It seems that you already have that role! Try removing it first with the ' + botconfig.prefix + 'delrole command!');
-            }
-          } else {
-            msg.channel.send('The role ' + '`' + suffix + '`' + ' does not exist!');
-          }
-        } else {
-          msg.channel.send("That role isn't one you can add yourself to! Please run the " + botconfig.prefix + 'roles command to find out which ones are allowed.');
-        }
-      } else {
-        msg.channel.send('Please specify a role. Type ' + botconfig.prefix + 'roles to see which you may add!');
-      }
-    }
+    // Confirm that the role exists on the server and if not then be sure to send a nag message
+    if(!baserole)
+      return send("The base role of " + rolelist.baserole + " has been set in config but is missing from the server");
+    // Confirm if the user has the baserole already, including if it was added just now
+    if(msg.member.roles.find('name', baserole.name))
+      return;
+    // Add the base role and avoid spamming the user by only mentioning them in the previous message
+    msg.member.addRole(baserole).then(send("We also added the base " + rolelist.baserole + " role for you!"));
   }
 };
 exports.delrole = {
@@ -61,33 +60,30 @@ exports.delrole = {
   description: 'Deletes the specified role from your account',
   process: function(bot, msg, suffix) {
     // Here in the bot, msg and suffix are available, this function can be async if needed.
-    let oldrole = msg.guild.roles.find('name', suffix);
-    // Checks if the user put a role in the message.
-    if (inPrivate(msg)) {
-      msg.channel.send('You can not set roles in DMs! Please go to the Discord server to do this.');
-      return;
-    } else {
-      if (suffix) {
-        // Checks if the role mentioned in the message is in the allowed roles listed in the Wunderbot config.
-        if (rolelist.allowedroles.includes(suffix)) {
-          // Checks if the role exists in the Discord server
-          if (oldrole !== null) {
-            // Checks if the member has the role that they are trying to add
-            if (msg.member.roles.find('name', suffix)) {
-              msg.member.removeRole(oldrole).then(msg.channel.send(msg.member + ' has been removed from the ' + suffix + ' role!'));
-            } else {
-              msg.channel.send("You don't seem to have that role! Try adding it first with the " + botconfig.prefix + 'addrole command!');
-            }
-          } else {
-            msg.channel.send('The role ' + '`' + suffix + '`' + ' does not exist!');
-          }
-        } else {
-          msg.channel.send("That role isn't one you can add yourself to! Please run the " + botconfig.prefix + 'roles command to find out which ones are allowed.');
-        }
-      } else {
-        msg.channel.send('Please specify a role. Type ' + botconfig.prefix + 'roles to see which you may add!');
-      }
-    }
+    // Make sure to eliminate case sensitivity, do this here to only perform the sweep once.
+    let oldrole = msg.guild.roles.find(role => role.name.toLowerCase() === suffix.toLowerCase());
+    // Provide shortened syntax for the sake of code cleanliness
+    let send = (msgTxt) => { msg.channel.send(msgTxt); return; };
+    let rolecmd = botconfig.prefix + "roles";
+    
+    // Checks if the user has messaged the bot via Direct Message
+    if (inPrivate(msg))
+      return send('You can not set roles in DMs! Please go to the Discord server to do this.');
+    // Checks if the user included a role in their message
+    if (!suffix)
+      return send("Please specify a role. Type " + rolecmd + " to see which you may remove yourself!");
+    // Checks if there is a matching role found on the server
+    if(!newrole)
+      return send("The role specified `" + suffix + "` does not exist on this server!");
+    // Checks that the allowed roles against the matched role's name, since this eliminates case sensitivity issues
+    if(!rolelist.allowedroles.includes(oldrole.name))
+      return send("That role isn't one you can remove yourself! If you need it removed, please ask a moderator!");
+    // Use the matched name to check against the member's existing roles
+    if(!msg.member.roles.find('name', oldrole.name))
+      return send("It seems you don't actually have the " + oldrole.name + "role! Mission accomplished!");
+    
+    // Assuming all these factors succeed, add the role
+    msg.member.removeRole(oldrole).then(send(msg.member + " has been removed from the " + oldrole.name + " role!"));
   }
 };
 exports.roles = {


### PR DESCRIPTION
Eliminates nesting of if-else statements and follows imperative control logic, making it much clearer what error messages are which and what order logic is handled in. Also neatens up the calls to 'msg.channel.send' into a single compact function declaration. Also eliminates case sensitivity entirely with a minimal performance hit by only performing '.toLowerCase()' on the first check for new/oldrole, though this could be replaced with a regexp object test instead. Every other comparison uses the matched role's name as this is guaranteed to be the correct case, assuming no issues with the config itself. This means users can enter the role in any case, preventing the biggest irritation to most users besides spelling errors.