### PR TITLE
Fix !why typo causing build failure

### DIFF
--- a/config/commands.json
+++ b/config/commands.json
@@ -913,6 +913,7 @@
         "icon_url": "https://spee.ch/2/pinkylbryheart.png"
       }
     }
+  },
   
   "!piratebay": {
     "usage": "",


### PR DESCRIPTION
The !why commit seems to have included a typo as evidenced by the build failure logs, causing all other builds to fail:
https://travis-ci.com/lbryio/lbry-wunderbot/builds/130782835
This simply replaces the missing bracket and comma.

Recreated due to piling on too many changes in previous PR, sorry about that.