### PR TITLE
Fix LBRY Linker URLs

### DIFF
--- a/bot/modules/lbrylink.js
+++ b/bot/modules/lbrylink.js
@@ -27,7 +27,10 @@ exports.lbrylink = async function(bot, msg, suffix) {
 
       //clean URLS from any prepended or appended extra chars
       for (let i = 0; i < urls.length; i++) {
-        urls[i] = urls[i].replace(/^lbry:\/\//g, 'https://open.lbry.com/').replace(/\W+$/g, '');
+        urls[i] = urls[i]
+          .replace(/^lbry:\/\//g, 'https://open.lbry.com/')
+          .replace(/\W+$/g, '')
+          .replace(/#/g, ':');
       }
       const linkEmbed = new RichEmbed();
       linkEmbed


### PR DESCRIPTION
This PR fixes the LBRY Linker so that the links given actually work.

Previously, if you were to type in the link `lbry://@MH#5/Response#7` would generate `https://open.lbry.com/@MH#5/Response#7`, and it would ignore everything after the first `#` due to how document fragments work.

This PR fixes this by replacing all of the `#`'s in the url with `:`'s.