### PR TITLE
Changes to !rewards, !rewardsapproval and !verify

### DIFF
--- a/config/commands.json
+++ b/config/commands.json
@@ -374,7 +374,7 @@
     "bundle": {
       "url": "",
       "title": "",
-      "description": "[Rewards](https://lbry.com/faq/rewards) are given to legitimate users who are using the system (and in turn are testing things for us). In order to redeem rewards, you may need to verify your identity through phone number,credit card, or other manual methods. Learn more by typing !verify.",
+      "description": "[Rewards](https://lbry.com/faq/rewards) are given to legitimate users who are using the system (and in turn are testing things for us). In order to redeem rewards, you may need to verify your identity through phone number,credit card, or other manual methods. Learn how to verify by typing !verify or !cc",
       "color": 7976557,
       "author": {
         "name": "Rewards",

--- a/config/commands.json
+++ b/config/commands.json
@@ -7,7 +7,7 @@
       "url": "",
       "title": "",
       "description": "filled at runtime",
-      "color": 7976557,
+      "color": 7976557,FF
       "author": {
         "name": "List of Helpful LBRY Commands",
         "url": "",
@@ -310,7 +310,7 @@
     "bundle": {
       "url": "",
       "title": "",
-      "description": "Names exist so that we can map a human readable and understandable word or term to a more difficult to remember number or ID. In the traditional domain system, names map to numerical IP addresses. In LBRY, names map to a unique, permanent ID representing a piece of digital content and/or a publisher identity. Learn more **[HERE](https://lbry.com/faq/naming)**",
+      "description": "Names exist so that we can map a human readable and understandable word or term to a more difficult to remember number or ID. In the traditional domain system, names map to numerical ! addresses. In LBRY, names map to a unique, permanent ID representing a piece of digital content and/or a publisher identity. Learn more **[HERE](https://lbry.com/faq/naming)**",
       "color": 7976557,
       "author": {
         "name": "How Does LBRY Naming Work?",
@@ -390,7 +390,7 @@
     "bundle": {
       "url": "",
       "title": "",
-      "description": "If you would like to be approved for rewards, please go to <#571001864271691805> and send a Direct Message to @RewardsBot#0287 \n You can do this by right clicking on the name, and selecting Message. . A LBRY mod will get back to you as soon as possible. We appreciate your patience. Only one account per email/ip/family is allowed access to LBRY Rewards. Check out our [Rewards FAQ](https://lbry.com/faq/rewards) to know more about rewards.",
+      "description": "If you would like to be approved for rewards, please go to <#571001864271691805> and send a Direct Message to @RewardsBot#0287 \n You can do this by right clicking on the name, and selecting Message. . A LBRY mod will get back to you as soon as possible. We appreciate your patience. Only one account per email/ip/household is allowed access to LBRY Rewards. Check out our [Rewards FAQ](https://lbry.com/faq/rewards) to know more about rewards.",
       "color": 7976557,
       "author": {
         "name": "Getting approved for rewards",

--- a/config/commands.json
+++ b/config/commands.json
@@ -390,7 +390,7 @@
     "bundle": {
       "url": "",
       "title": "",
-      "description": "If you would like to be approved for rewards, please go to <#571001864271691805> and send a Direct Message to @RewardsBot#0287 \n You can do this by right clicking on the name, and selecting Message. . A LBRY mod will get back to you as soon as possible. We appreciate your patience. Only one account per household is allowed access to LBRY Rewards. Check out our [Rewards FAQ](https://lbry.com/faq/rewards) to know more about rewards.",
+      "description": "If you would like to be approved for rewards, please go to <#571001864271691805> and send a Direct Message to @RewardsBot#0287 \n You can do this by right clicking on the name, and selecting Message. . A LBRY mod will get back to you as soon as possible. We appreciate your patience. Only one account per email/ip/family is allowed access to LBRY Rewards. Check out our [Rewards FAQ](https://lbry.com/faq/rewards) to know more about rewards.",
       "color": 7976557,
       "author": {
         "name": "Applying for Rewards Approval",

--- a/config/commands.json
+++ b/config/commands.json
@@ -393,7 +393,7 @@
       "description": "If you would like to be approved for rewards, please go to <#571001864271691805> and send a Direct Message to @RewardsBot#0287 \n You can do this by right clicking on the name, and selecting Message. . A LBRY mod will get back to you as soon as possible. We appreciate your patience. Only one account per email/ip/family is allowed access to LBRY Rewards. Check out our [Rewards FAQ](https://lbry.com/faq/rewards) to know more about rewards.",
       "color": 7976557,
       "author": {
-        "name": "Applying for Rewards Approval",
+        "name": "Getting approved for rewards",
         "url": "",
         "icon_url": "https://spee.ch/2/pinkylbryheart.png"
       }

--- a/config/commands.json
+++ b/config/commands.json
@@ -7,7 +7,7 @@
       "url": "",
       "title": "",
       "description": "filled at runtime",
-      "color": 7976557,FF
+      "color": 7976557,
       "author": {
         "name": "List of Helpful LBRY Commands",
         "url": "",

--- a/config/commands.json
+++ b/config/commands.json
@@ -390,7 +390,7 @@
     "bundle": {
       "url": "",
       "title": "",
-      "description": "If you would like to be approved for rewards, please go to <#571001864271691805> and send a Direct Message to @RewardsBot#0287 \n You can do this by right clicking on the name, and selecting Message. . A LBRY mod will get back to you as soon as possible. We appreciate your patience. Only one account per email/ip/household is allowed access to LBRY Rewards. Check out our [Rewards FAQ](https://lbry.com/faq/rewards) to know more about rewards.",
+      "description": "If you would like to be approved for rewards, please go to <#571001864271691805> and send a Direct Message to @RewardsBot#0287 saying "Hi" \n You can do this by right clicking on the name, and selecting Message. A LBRY mod will get back to you as soon as possible. We appreciate your patience. Only one account per email/ip/household is allowed access to LBRY Rewards. Check out our [Rewards FAQ](https://lbry.com/faq/rewards) to know more about rewards.",
       "color": 7976557,
       "author": {
         "name": "Getting approved for rewards",

--- a/config/commands.json
+++ b/config/commands.json
@@ -374,11 +374,27 @@
     "bundle": {
       "url": "",
       "title": "",
-      "description": "[Rewards](https://lbry.com/faq/rewards) are given to legitimate users who are using the system (and in turn are testing things for us). In order to redeem rewards, you may need to verify your identity through phone number,credit card, or other manual methods.",
+      "description": "[Rewards](https://lbry.com/faq/rewards) are given to legitimate users who are using the system (and in turn are testing things for us). In order to redeem rewards, you may need to verify your identity through phone number,credit card, or other manual methods. Learn more by typing !verify.",
       "color": 7976557,
       "author": {
         "name": "Rewards",
         "url": "https://lbry.com/faq/rewards",
+        "icon_url": "https://spee.ch/2/pinkylbryheart.png"
+      }
+    }
+  },
+ "!verify": {
+    "usage": "",
+    "description": "Rewards Approval Help Message",
+    "operation": "send",
+    "bundle": {
+      "url": "",
+      "title": "",
+      "description": "If you would like to be approved for rewards, please go to <#571001864271691805> and send a Direct Message to @RewardsBot#0287 \n You can do this by right clicking on the name, and selecting Message. . A LBRY mod will get back to you as soon as possible. We appreciate your patience. Only one account per household is allowed access to LBRY Rewards. Check out our [Rewards FAQ](https://lbry.com/faq/rewards) to know more about rewards.",
+      "color": 7976557,
+      "author": {
+        "name": "Applying for Rewards Approval",
+        "url": "",
         "icon_url": "https://spee.ch/2/pinkylbryheart.png"
       }
     }
@@ -411,38 +427,6 @@
       "author": {
         "name": "Credit Card Verification",
         "url": "https://lbry.com/faq/identity-requirements",
-        "icon_url": "https://spee.ch/2/pinkylbryheart.png"
-      }
-    }
-  },
-  "!verify": {
-    "usage": "",
-    "description": "How to become Rewards approved",
-    "operation": "send",
-    "bundle": {
-      "url": "",
-      "title": "",
-      "description": "Please download the latest version from [HERE](https://lbry.com/get) Upon install, you'll be greeted with a welcome message. If you already had the app installed, please go to the wallet (bank icon in the top right) > Rewards - This should show your current status. New users will need to get their rewards approved in order to access Rewards. Type !cc or !rewardsapproval for more information.",
-      "color": 7976557,
-      "author": {
-        "name": "How to become Rewards approved",
-        "url": "",
-        "icon_url": "https://spee.ch/2/pinkylbryheart.png"
-      }
-    }
-  },
-  "!rewardsapproval": {
-    "usage": "",
-    "description": "Rewards Approval Help Message",
-    "operation": "send",
-    "bundle": {
-      "url": "",
-      "title": "",
-      "description": "If you would like to be approved for rewards, please go to <#571001864271691805> and send a Direct Message to @RewardsBot#0287 \n You can do this by right clicking on the name, and selecting Message. . A LBRY mod will get back to you as soon as possible. We appreciate your patience. Only one account per household is allowed access to LBRY Rewards. Check out our [Rewards FAQ](https://lbry.com/faq/rewards) to know more about rewards.",
-      "color": 7976557,
-      "author": {
-        "name": "Applying for Rewards Approval",
-        "url": "",
         "icon_url": "https://spee.ch/2/pinkylbryheart.png"
       }
     }


### PR DESCRIPTION
changing !rewardsapproval to !verify to 
A. Stop double commands
B. It's pretty much the same thing, verify/approval potato potata
and deleting the !verify command (Eniamza votes this) since it's really unrelated mainly since anything mentioned there are already spread across other commands. 